### PR TITLE
fix: case sensitivity issues on linux

### DIFF
--- a/src/Compoents/PromptEditor/Lib/parsePrompts/parsers/Midjourney/index.ts
+++ b/src/Compoents/PromptEditor/Lib/parsePrompts/parsers/Midjourney/index.ts
@@ -1,4 +1,4 @@
-import { IPromptWord, PromptWordType } from "../../ParsePrompts"
+import { IPromptWord, PromptWordType } from "../../parsePrompts"
 import { translateZh2En } from "../../../translatePrompts"
 import { IPromptGroup } from "../../../../Sub/PromptWork"
 


### PR DESCRIPTION
When I run the program in Ubuntu system, I get the following error: 'Failed to resolve import "../../ParsePrompts" from "src/Compoents/PromptEditor/Lib/parsePrompts/parsers/Midjourney/index.ts". Does the file exist?' 
Linux platform is case-sensitive for file names, while Windows platform is not case-sensitive. You can find more information about this in the following document: 
https://learn.microsoft.com/en-us/windows/wsl/case-sensitivity